### PR TITLE
# Drop support for Ruby 2.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,21 +7,14 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-          - '2.6'
           - '2.7'
           - '3.0'
+          - '3.1'
         gemfile:
-          - gemfiles/Gemfile.rails52
           - gemfiles/Gemfile.rails60
           - gemfiles/Gemfile.rails61
-          # - gemfiles/Gemfile.rails70 # not yet supported
+          - gemfiles/Gemfile.rails70
         exclude:
-          # rails 5.2 requires ruby < 3.0
-          # https://github.com/rails/rails/issues/40938
-          - ruby-version: '3.0'
-            gemfile: 'gemfiles/Gemfile.rails52'
-          - ruby-version: '3.1'
-            gemfile: 'gemfiles/Gemfile.rails52'
           # rails 7.0 requires ruby >= 2.7
           # https://www.fastruby.io/blog/ruby/rails/versions/compatibility-table.html
           - ruby-version: '2.6'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
-*no unreleased changes*
+### Fixed
+* Drop support for Ruby 2.6
+* Support Ruby 3.1, Rails 7.0
+* Replace Public Health England naming with NHS Digital
 
 ## 1.1.0 / 2021-11-25
 ### Added

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Public Health England
+Copyright (c) 2015-2022 NHS Digital
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# TNQL [![Build Status](https://github.com/publichealthengland/tnql/workflows/Test/badge.svg)](https://github.com/publichealthengland/tnql/actions?query=workflow%3Atest) [![Gem Version](https://badge.fury.io/rb/tnql.svg)](https://rubygems.org/gems/tnql)
+# TNQL [![Build Status](https://github.com/NHSDigital/tnql/workflows/Test/badge.svg)](https://github.com/NHSDigital/tnql/actions?query=workflow%3Atest) [![Gem Version](https://badge.fury.io/rb/tnql.svg)](https://rubygems.org/gems/tnql)
 
-Tumour Natural Query Language (TNQL) is a [Treetop](http://treetop.rubyforge.org/) driven Domain Specific Language (DSL) used by the Public Health England (PHE) National Cancer Registration and Analysis Service (NCRAS) to identify cohorts of tumours.
+Tumour Natural Query Language (TNQL) is a [Treetop](http://treetop.rubyforge.org/) driven Domain Specific Language (DSL) used by the NHS Digital (NHS-D) National Cancer Registration and Analysis Service (NCRAS) to identify cohorts of tumours.
 
 Used for analysis, research and day-to-day operations, it was first created in March 2011 to empower non-technical users to write sophisticated human readable queries without the need to know or understand the underlying datastore and/or schema.
 
@@ -64,7 +64,7 @@ PLEASE NOTE: A side-effect of decoupling TNQL from the NCRAS SQL adapter is that
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/PublicHealthEngland/tnql.
+Bug reports and pull requests are welcome on GitHub at https://github.com/NHSDigital/tnql.
 
 This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 

--- a/gemfiles/Gemfile.rails52
+++ b/gemfiles/Gemfile.rails52
@@ -1,5 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec path: '..'
-
-gem 'rails', '~> 5.2.0'

--- a/tnql.gemspec
+++ b/tnql.gemspec
@@ -1,4 +1,3 @@
-# coding: utf-8
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'tnql/version'
@@ -6,36 +5,36 @@ require 'tnql/version'
 Gem::Specification.new do |spec|
   spec.name          = 'tnql'
   spec.version       = Tnql::VERSION
-  spec.authors       = ['PHE NDR IT Development Team']
+  spec.authors       = ['NHSD NDRS Development Team']
   spec.email         = []
 
   spec.summary       = 'Tumour Natural Query Language'
   spec.description   = 'Domain Specific Language for querying PHE NCRAS datastores'
-  spec.homepage      = 'https://github.com/PublicHealthEngland/tnql'
+  spec.homepage      = 'https://github.com/NHSDigital/tnql'
   spec.license       = 'MIT'
 
+  gem_files          = %w[CHANGELOG.md CODE_OF_CONDUCT.md LICENSE.txt README.md Rakefile
+                          app config db lib]
   spec.files         = `git ls-files -z`.split("\x0").
-                       reject { |f| f.match(%r{^(test|spec|features)/}) }
-  # SECURE BNS 2018-08-06: Minimise sharing of (public-key encrypted) slack secrets in .travis.yml
-  spec.files         -= %w[.travis.yml] # Not needed in the gem
+                       select { |f| gem_files.include?(f.split('/')[0]) }
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.6'
+  spec.required_ruby_version = '>= 2.7'
 
-  spec.add_dependency 'activesupport', '>= 3.2.18', '< 7'
+  spec.add_dependency 'activesupport', '>= 3.2.18', '< 7.1'
+  spec.add_dependency 'chronic', '~> 0.3'
   spec.add_dependency 'ndr_support', '>= 3.0', '< 6'
   spec.add_dependency 'treetop', '>= 1.4.10'
-  spec.add_dependency 'chronic', '~> 0.3'
 
-  spec.add_development_dependency 'ndr_dev_support', '~> 6.0'
   spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'minitest', '>= 5.0.0'
-  spec.add_development_dependency 'pry'
   spec.add_development_dependency 'guard'
-  spec.add_development_dependency 'guard-rubocop'
   spec.add_development_dependency 'guard-minitest'
+  spec.add_development_dependency 'guard-rubocop'
+  spec.add_development_dependency 'minitest', '>= 5.0.0'
+  spec.add_development_dependency 'ndr_dev_support', '>= 6.0', '< 8.0'
+  spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'rake'
   spec.add_development_dependency 'terminal-notifier-guard' if RUBY_PLATFORM =~ /darwin/
 end


### PR DESCRIPTION
# Support Ruby 3.1, Rails 7.0
# Replace Public Health England naming with NHS Digital