### PR TITLE
Restrict treetop gem dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
-* no unreleased changes *
+### Fixed
+* Restrict treetop gem dependency
 
 ## 1.1.2 / 2024-11-18
 ### Fixed

--- a/gemfiles/Gemfile.rails70
+++ b/gemfiles/Gemfile.rails70
@@ -3,3 +3,6 @@ source 'https://rubygems.org'
 gemspec path: '..'
 
 gem 'rails',  '~> 7.0.0'
+
+# Latest concurrent-ruby breaks Rails < 7.1. See https://github.com/rails/rails/issues/54260
+gem 'concurrent-ruby', '1.3.4'

--- a/tnql.gemspec
+++ b/tnql.gemspec
@@ -2,6 +2,9 @@ lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'tnql/version'
 
+# We list development dependencies for all Rails versions here.
+# Rails version-specific dependencies can go in the relevant Gemfile.
+# rubocop:disable Gemspec/DevelopmentDependencies
 Gem::Specification.new do |spec|
   spec.name          = 'tnql'
   spec.version       = Tnql::VERSION
@@ -26,7 +29,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activesupport', '>= 7.0', '< 8.1'
   spec.add_dependency 'chronic', '~> 0.3'
   spec.add_dependency 'ndr_support', '>= 3.0', '< 6'
-  spec.add_dependency 'treetop', '>= 1.4.10'
+  # treetop 1.6.14 causes errors. I think this may be a buggy release and fixed soon,
+  # but I'll restrict the version we use for now.
+  spec.add_dependency 'treetop', '~> 1.6.12', '< 1.6.14'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'guard'
@@ -38,3 +43,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'terminal-notifier-guard' if RUBY_PLATFORM =~ /darwin/
 end
+# rubocop:enable Gemspec/DevelopmentDependencies


### PR DESCRIPTION
Restrict `treetop` gem dependency. `treetop` 1.6.14 causes errors. I think this may be a buggy release and fixed soon, but I'll restrict the version we use for now so that everything continues to work.

Fix `concurrent-ruby` version to 1.3.4 for older Rails versions.